### PR TITLE
Changes occurences of Brücke to bridge since it is less confusing

### DIFF
--- a/gluon_gateway_doku/configuration/daemons/ddi.rst
+++ b/gluon_gateway_doku/configuration/daemons/ddi.rst
@@ -145,7 +145,7 @@ Wir installieren uns zunächst das Programm ``acl`` nach, stoppen den DHCPd, und
 
 Unter etc/default/isc-dhcp-server konfigurieren wir, auf welchen Interfaces der dhcpd lauschen soll.
 
-Wir wählen die beiden Brücken::
+Wir wählen die beiden bridges::
 
     INTERFACES="mzBR wiBR"
 

--- a/gluon_gateway_doku/configuration/interfaces.rst
+++ b/gluon_gateway_doku/configuration/interfaces.rst
@@ -5,9 +5,9 @@ Netzwerk Interfaces
 
 /etc/network/interfaces
 
-Wir richten uns hier je eine Brücke pro Mesh-Wolke, die wir versorgen wollen, ein.
+Wir richten uns hier je eine bridge pro Mesh-Wolke, die wir versorgen wollen, ein.
 
-Auf diese Brücken binden sich die Dienste (wie DHCP, DNS, NTP, etc..).
+Auf diese bridges binden sich die Dienste (wie DHCP, DNS, NTP, etc..).
 Das hoch/runterfahren der VPNs oder das (neu-)starten von Diensten kann dadurch unabhängig voneinander geschehen.
 
 .. seealso::
@@ -17,7 +17,7 @@ Das hoch/runterfahren der VPNs oder das (neu-)starten von Diensten kann dadurch 
     - :ref:`policyrouting`
     - :ref:`exitvpn`
 
-Hier eine Brücke mit IPv4 und IPv6 am Beispiel von Wiesbaden::
+Hier eine bridge mit IPv4 und IPv6 am Beispiel von Wiesbaden::
 
     auto wiBR
     iface wiBR inet static


### PR DESCRIPTION
In my opinion it's confusing if you relate to "bridges" as "brücke" since on the cli most config options are in english. So google results will give you more results even if you are a German user.
